### PR TITLE
Add permanent setting via localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Allows you to toggle the display of all errors, warnings, and notices in the Wor
 2. When you click the 'Toggle Admin Notices', it will hide all of the notices on the current page.
 3. When you click on the menu item again, it will display all of the options.
 
-***Note***: *The final version of the plugin will allow you to persist your setting across page requests.*
-
 ## Installation
 
 ### Using The WordPress Dashboard

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -3,10 +3,10 @@
  *
  * @package TAN\Admin\JS
  */
-(function( $ ) {
+( function( $ ) {
 	'use strict';
 
-	$(function() {
+	$( function() {
 
 		// Go ahead and setup references to the plugin menu item and all admin notices.
 		var $admin_button = $( '#wp-admin-bar-toggle-admin-notices a' ),
@@ -45,5 +45,5 @@
 		if ( 'hide' === currentState ) {
 			$messages.hide();
 		}
-	});
-})( jQuery );
+	} );
+} )( jQuery );

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -10,7 +10,21 @@
 
 		// Go ahead and setup references to the plugin menu item and all admin notices.
 		var $admin_button = $( '#wp-admin-bar-toggle-admin-notices a' ),
-			$messages     = $( '.notice, .warning, .error' );
+			$messages     = $( '.notice, .warning, .error' ),
+			currentState  = localStorage.getItem( 'toggleAdminNoticesState' );
+
+		if ( null === currentState ) {
+			currentState = 'show';
+			localStorage.setItem( 'toggleAdminNoticesState', currentState );
+		}
+
+		/**
+		 * Toggle the state and save the setting to the local storage
+		 */
+		var toggleState = function toggleState() {
+			currentState = 'show' === currentState ? 'hide' : 'show';
+			localStorage.setItem( 'toggleAdminNoticesState', currentState );
+		}
 
 		/**
 		 * Hide all of the messages when the option is include and restore the menu items'
@@ -21,6 +35,15 @@
 
 			$messages.toggle( 'medium' );
 			$( this ).trigger( 'blur' );
-		});
+
+			toggleState();
+		} );
+
+		/**
+		 * Permanently hidden
+		 */
+		if ( 'hide' === currentState ) {
+			$messages.hide();
+		}
 	});
 })( jQuery );


### PR DESCRIPTION
Hi @tommcfarlin,

I've noticed [this tweet](https://twitter.com/tommcfarlin/status/879724049789837312) yesterday and today morning I have an usecase. However, the hide didn't work across the pages (it was not permanent), so I've added the necessarry logic via localStorage.

I will appreciate if you can merge this PR.